### PR TITLE
Jellyfin 10.11.2 Compatibility

### DIFF
--- a/Jellyfin.Plugin.JavaScriptInjector/Jellyfin.Plugin.JavaScriptInjector.csproj
+++ b/Jellyfin.Plugin.JavaScriptInjector/Jellyfin.Plugin.JavaScriptInjector.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <JellyfinVersion>10.11.0</JellyfinVersion>
-    <TargetFramework Condition="$(JellyfinVersion.StartsWith('10.11.0'))">net9.0</TargetFramework>
+    <JellyfinVersion>10.11.2</JellyfinVersion>
+    <TargetFramework Condition="$(JellyfinVersion.StartsWith('10.11.'))">net9.0</TargetFramework>
     <TargetFramework Condition="'$(JellyfinVersion)' == '10.10.7'">net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -22,7 +22,7 @@
       <Compile Remove="JellyfinVersionSpecific/10.10.7/*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="!$(JellyfinVersion.StartsWith('10.11.0'))">
+  <ItemGroup Condition="!$(JellyfinVersion.StartsWith('10.11.'))">
       <Compile Remove="JellyfinVersionSpecific/10.11.0/*.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Jellyfin bumped to 10.11.2, but the plugin csproj still targets 10.11.0. Because the conditional compile excludes JellyfinVersionSpecific/10.11.0, no StartupServiceHelper is compiled for 10.11.2 and the injector never runs.

Fix
Set JellyfinVersion in Jellyfin.Plugin.JavaScriptInjector.csproj to 10.11.2.
- Relax the StartsWith checks from "10.11.0" to "10.11.", so the 10.11 helper stays included for all 10.11.x builds.

Testing
- dotnet build (net9.0) ✔️
- Manual verification on Jellyfin 10.11.2: plugin installs, scripts inject successfully.